### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-and-push
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/gofrolist/mtg-commander-picker/security/code-scanning/2](https://github.com/gofrolist/mtg-commander-picker/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `deploy` job. Based on the actions performed in the `deploy` job, the minimal required permissions are `contents: read` (to read repository contents) and `id-token: write` (if OpenID Connect tokens are needed for authentication). Additionally, since the job uses the `FLY_API_TOKEN` secret for deployment, no other write permissions are necessary.

The `permissions` block will be added directly under the `deploy` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
