### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/gofrolist/mtg-commander-picker/security/code-scanning/1](https://github.com/gofrolist/mtg-commander-picker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `test` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the `test` job only runs commands to test the frontend and backend, it does not require any write permissions. The minimal required permission is `contents: read`, which allows the job to read the repository contents.

The `permissions` block will be added directly under the `test` job definition, ensuring that it applies only to this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
