### PR TITLE
Fix error display bug in frontend

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -80,7 +80,7 @@ export default function App() {
           setStep(s => s + 1);
         }
       })
-      .catch((e) => setError(e))
+      .catch((e) => setError(e && e.message ? e.message : String(e)))
       .finally(() => setLoading(false));
   };
 


### PR DESCRIPTION
## Summary
- ensure error messages show actual text instead of `[object Object]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68408cb5df688331a5c527c9d3ac3785