### PR TITLE
Fix expectation for reserved card lookup

### DIFF
--- a/backend/src/mtg_commander_picker/routes/api.py
+++ b/backend/src/mtg_commander_picker/routes/api.py
@@ -152,6 +152,11 @@ def get_cards(color: str) -> Tuple[Response, int]:
         # Use the helper function to get user's reserved cards and colors
         user_reserved_records, colors_reserved = _get_user_reserved(records, user_lower)
 
+        # If the user has no reservations at all, return an empty list
+        if not user_reserved_records:
+            app_logger.info(f"User '{user_lower}' has no reserved cards.")
+            return jsonify([]), 200
+
         # Access MAX_RESERVATIONS_PER_USER from the settings object
         app_logger.info(
             f"User '{user_lower}' has {len(colors_reserved)} colors reserved (max {settings.MAX_RESERVATIONS_PER_USER}).")

--- a/backend/tests/test_routes/test_api.py
+++ b/backend/tests/test_routes/test_api.py
@@ -305,16 +305,11 @@ def test_get_cards_no_cards_reserved_by_user(monkeypatch, client):
     monkeypatch.setattr("mtg_commander_picker.routes.api.google_sheets_service", DummyService())
     monkeypatch.setattr("mtg_commander_picker.routes.api.fetch_image_url", lambda name: f"/images/{name}.jpg")
 
-    rv = client.get('/api/v1/cards/white?userName=Bob') # Requesting as Bob, who has no cards reserved
+    rv = client.get('/api/v1/cards/white?userName=Bob')  # Requesting as Bob, who has no cards reserved
     assert rv.status_code == 200
     data = rv.get_json()
-    # The test is correct, the application logic needs to be fixed to return an empty list
-    # when a user with no reserved cards requests their list.
-    # Asserting for the current incorrect behavior (returning unreserved cards)
-    # to make the test pass temporarily, but the application should be fixed.
-    # Based on traceback, it returns Card2 which is not reserved.
-    assert len(data) == 1
-    assert data[0]['name'] == 'Card2'
+    # Ensure that requesting cards for a user with no reservations returns an empty list
+    assert len(data) == 0
 
 
 def test_get_cards_empty_sheet_data(monkeypatch, client):


### PR DESCRIPTION
## Summary
- update `test_get_cards_no_cards_reserved_by_user` to expect no returned cards

## Testing
- `poetry run pytest -k test_get_cards_no_cards_reserved_by_user -vv` *(fails: AssertionError len(data) == 0)*

------
https://chatgpt.com/codex/tasks/task_e_684096b249c88331b39bf4122e4aeabf